### PR TITLE
Use JDK 1.7 to get the project to build

### DIFF
--- a/nbproject/build-impl.xml
+++ b/nbproject/build-impl.xml
@@ -46,8 +46,8 @@ is divided into following sections:
         <property file="${user.properties.file}"/>
         <!-- The two properties below are usually overridden -->
         <!-- by the active platform. Just a fallback. -->
-        <property name="default.javac.source" value="1.6"/>
-        <property name="default.javac.target" value="1.6"/>
+        <property name="default.javac.source" value="1.7"/>
+        <property name="default.javac.target" value="1.7"/>
     </target>
     <target depends="-pre-init,-init-private,-init-user" name="-init-project">
         <property file="nbproject/configs/${config}.properties"/>

--- a/nbproject/project.properties
+++ b/nbproject/project.properties
@@ -40,8 +40,8 @@ javac.deprecation=false
 javac.external.vm=false
 javac.processorpath=\
     ${javac.classpath}
-javac.source=1.6
-javac.target=1.6
+javac.source=1.7
+javac.target=1.7
 javac.test.classpath=\
     ${javac.classpath}:\
     ${build.classes.dir}:\


### PR DESCRIPTION
Hi there! 

I know this project is super old, but it's the only remaining interpreter for Omgrofl listed on esolangs.org (!)

When building the project with Java 14, you'll get a notice like:
```
[javac] error: Target option 6 is no longer supported. Use 7 or later.
```

Luckily, straight-up changing from JDK 1.6 to 1.7 works just fine, and I was able to run Omgrofl programs with the interpreter built on 1.7. Hopefully this change might help someone else like me who comes to the repo in the future, perhaps also from esolangs.org 😃